### PR TITLE
[FEAT] request 함수 구현

### DIFF
--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "expo-router";
-import { createContext, useState, useEffect } from "react";
+import { createContext, useState, useEffect, useContext } from "react";
 import * as SecureStore from "expo-secure-store";
-
 import axios from "axios";
-
+import { request } from "../utils/request";
+import { AuthContext } from "../_layout";
 interface HomeForm {
   email: string;
   nickname: string;
@@ -31,26 +31,21 @@ export default function Home() {
     alarm: "",
     cloverCount: 0,
   });
-
+  const { setIsLoggedIn } = useContext(AuthContext);
   useEffect(() => {
     const loadUser = async () => {
       try {
-        // 1. 토큰 가져오기
-        const accessToken = await SecureStore.getItemAsync("accessToken");
-        console.log(accessToken);
-        if (!accessToken) return;
-
-        // 2. API 호출
-        const res = await axios.get(
-          "https://test.clodycorp.com/api/v2/user/info",
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          },
-        );
-
-        const user = res.data.data;
+        // 1. API 호출
+        const res = await request("/api/v2/user/info");
+        // const res = await axios.get(
+        //   "https://test.clodycorp.com/api/v2/user/info",
+        //   {
+        //     headers: {
+        //       Authorization: `Bearer ${accessToken}`,
+        //     },
+        //   },
+        // );
+        const user = res.data;
         console.log(user);
         // 3. form에 데이터 세팅
         setForm({
@@ -63,6 +58,9 @@ export default function Home() {
           cloverCount: user.cloverCount,
         });
       } catch (err) {
+        if (err?.message === "토큰 재발급 실패") {
+          setIsLoggedIn(false);
+        }
         console.log("유저 정보 가져오기 실패", err);
       }
     };

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -93,10 +93,9 @@ export default function RootLayout() {
           }
           return;
         }
-        setIsLoggedIn(false);
-        return;
       } catch (e) {
         console.error(e);
+        setIsLoggedIn(false);
       }
     };
     async function loadFonts() {

--- a/app/utils/request.tsx
+++ b/app/utils/request.tsx
@@ -1,0 +1,61 @@
+import * as SecureStore from "expo-secure-store";
+import axios from "axios";
+import authService from "@/services/authService";
+const BASE_URL = "https://test.clodycorp.com";
+
+// ✅ 공통 요청 함수
+export const request = async (url, method = "GET", body = null) => {
+  try {
+    let accessToken = await SecureStore.getItemAsync("accessToken");
+
+    const res = await axios({
+      method,
+      url: `${BASE_URL}${url}`,
+      data: body,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return res.data;
+  } catch (error) {
+    try {
+      const status = error.response?.status;
+      switch (true) {
+        case status === 401:
+          console.log("토큰 만료 → refresh");
+          try {
+            const refreshToken = await SecureStore.getItemAsync("refreshToken");
+            await authService.reissueWithRefreshToken(refreshToken);
+            const accessToken = await SecureStore.getItemAsync("accessToken");
+            const retryRes = await axios({
+              method,
+              url: `${BASE_URL}${url}`,
+              data: body,
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            });
+            return retryRes.data;
+          } catch (reissueError) {
+            const err = new Error("토큰 재발급 실패");
+            throw err;
+          }
+
+        case status >= 400 && status < 500:
+          console.log("클라이언트 에러");
+          break;
+
+        case status >= 500:
+          console.log("서버 에러");
+          break;
+
+        default:
+          console.log("기타 에러");
+      }
+
+      throw error;
+    } catch (reissueError) {
+      throw reissueError;
+    }
+  }
+};

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -122,13 +122,8 @@ const isAccessTokenValid = async (accessToken: string): Promise<boolean> => {
         Authorization: `Bearer ${accessToken}`,
       },
     });
-
     return res.status === 200;
   } catch (e: any) {
-    if (e.response?.status === 401) {
-      return false;
-    }
-
     return false;
   }
 };
@@ -145,17 +140,13 @@ const reissueWithRefreshToken = async (
         },
       },
     );
-
     const newAccessToken = res.data.data.accessToken;
     const newRefreshToken = res.data.data.refreshToken;
-
     await SecureStore.setItemAsync("accessToken", newAccessToken);
     await SecureStore.setItemAsync("refreshToken", newRefreshToken);
-    console;
     return true;
   } catch (err) {
-    console.error("reissue failed:", err);
-    return false;
+    throw err;
   }
 };
 const kakaoSignUp = async (form) => {


### PR DESCRIPTION
## Related issue 🛠

- closed #5 

## Work Description ✏️

- 작업 내용
request 함수를 구현했습니다. api 호출 공통 모듈입니다. 
아래와 같이 사용하시면 됩니다.
### 📌 사용 예시 (유저 정보 조회)

```js
import { request } from "../utils/request";
import { useContext } from "react";
import { AuthContext } from "../_layout";  // app/_layout.tsx 것을 가져와야함
try {
  const { setIsLoggedIn } = useContext(AuthContext);
  // 1. API 호출
  const res = await request("/api/v2/user/info");

  const user = res.data;

} catch (err) {
  if (err?.message === "토큰 재발급 실패") {
    setIsLoggedIn(false);
  }
  console.error(err)
}
```
## Screenshot 📸

<img src="" width="360"/>

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
